### PR TITLE
feat(location): Implement Location module and simplify Profile schema

### DIFF
--- a/backend/glig/pom.xml
+++ b/backend/glig/pom.xml
@@ -29,6 +29,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -68,7 +69,6 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>8.0.2.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>com.okta.spring</groupId>
@@ -78,17 +78,28 @@
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
-			<version>1.6.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.mapstruct</groupId>
-			<artifactId>mapstruct-processor</artifactId>
-			<version>1.6.3</version>
+			<version>${org.mapstruct.version}</version>
 		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/glig/src/main/java/com/jttam/glig/configuration/SecurityConfiguration.java
+++ b/backend/glig/src/main/java/com/jttam/glig/configuration/SecurityConfiguration.java
@@ -22,16 +22,21 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
-                        .requestMatchers("/task/**").permitAll())
+                        .requestMatchers("/task/**").permitAll()
+                        .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
         return http.build();
     }
 
+    // Allow CORS for all origins and methods
+    //ONLY FOR DEVELOPMENT PURPOSES. RESTRICT IN PRODUCTION.
     @Bean
     UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173/"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+        // Allow any origin
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfile.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfile.java
@@ -35,8 +35,17 @@ public class EmployerProfile implements Serializable {
     @Column(name = "employer_type", nullable = false)
     private EmployerType employerType;
 
-    @Column(name = "location_id")
-    private Integer locationId;
+    @Column(name = "street_address")
+    private String streetAddress;
+
+    @Column(name = "postal_code")
+    private String postalCode;
+
+    @Column(name = "city")
+    private String city;
+
+    @Column(name = "country")
+    private String country;
 
     @Column(name = "bio", columnDefinition = "TEXT")
     private String bio;
@@ -92,12 +101,36 @@ public class EmployerProfile implements Serializable {
         this.employerType = employerType;
     }
 
-    public Integer getLocationId() {
-        return locationId;
+    public String getStreetAddress() {
+        return streetAddress;
     }
 
-    public void setLocationId(Integer locationId) {
-        this.locationId = locationId;
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
     }
 
     public String getBio() {

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileController.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileController.java
@@ -12,7 +12,7 @@ import com.jttam.glig.domain.employerprofile.dto.EmployerProfileResponse;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping("/api/employer-profiles")
+@RequestMapping("employer-profiles")
 public class EmployerProfileController {
 
     private final EmployerProfileService employerProfileService;

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileMapper.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileMapper.java
@@ -1,11 +1,10 @@
 package com.jttam.glig.domain.employerprofile;
 
+import com.jttam.glig.domain.employerprofile.dto.CreateEmployerProfileRequest;
+import com.jttam.glig.domain.employerprofile.dto.EmployerProfileResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-
-import com.jttam.glig.domain.employerprofile.dto.CreateEmployerProfileRequest;
-import com.jttam.glig.domain.employerprofile.dto.EmployerProfileResponse;
 
 @Mapper(componentModel = "spring")
 public interface EmployerProfileMapper {
@@ -13,6 +12,7 @@ public interface EmployerProfileMapper {
     EmployerProfileResponse toEmployerProfileResponse(EmployerProfile employerProfile);
 
     @Mapping(target = "employerProfileId", ignore = true)
+    @Mapping(target = "userId", ignore = true) // Keep ignoring userId from the request DTO
     @Mapping(target = "verified", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileRepository.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EmployerProfileRepository extends JpaRepository<EmployerProfile, Long> {
     Optional<EmployerProfile> findByUserId(String userId);
+    boolean existsByUserId(String userId);
 }

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/dto/CreateEmployerProfileRequest.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/dto/CreateEmployerProfileRequest.java
@@ -2,6 +2,7 @@ package com.jttam.glig.domain.employerprofile.dto;
 
 import com.jttam.glig.domain.employerprofile.EmployerType;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -13,7 +14,19 @@ public class CreateEmployerProfileRequest {
     @NotNull(message = "Employer type cannot be null")
     private EmployerType employerType;
 
-    private Integer locationId;
+    @Size(max = 255, message = "Street address cannot exceed 255 characters")
+    private String streetAddress;
+
+    @Size(max = 255, message = "Postal code cannot exceed 255 characters")
+    private String postalCode;
+
+    @NotBlank(message = "City cannot be blank")
+    @Size(max = 255, message = "City cannot exceed 255 characters")
+    private String city;
+
+    @NotBlank(message = "Country cannot be blank")
+    @Size(max = 255, message = "Country cannot exceed 255 characters")
+    private String country;
 
     @Size(max = 5000, message = "Bio cannot exceed 5000 characters")
     private String bio;
@@ -49,12 +62,36 @@ public class CreateEmployerProfileRequest {
         this.employerType = employerType;
     }
 
-    public Integer getLocationId() {
-        return locationId;
+    public String getStreetAddress() {
+        return streetAddress;
     }
 
-    public void setLocationId(Integer locationId) {
-        this.locationId = locationId;
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
     }
 
     public String getBio() {

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/dto/EmployerProfileResponse.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/dto/EmployerProfileResponse.java
@@ -9,7 +9,10 @@ public class EmployerProfileResponse {
     private Long employerProfileId;
     private String userId;
     private EmployerType employerType;
-    private Integer locationId;
+    private String streetAddress;
+    private String postalCode;
+    private String city;
+    private String country;
     private String bio;
     private String companyName;
     private String businessId;
@@ -23,11 +26,14 @@ public class EmployerProfileResponse {
     public EmployerProfileResponse() {
     }
 
-    public EmployerProfileResponse(Long employerProfileId, String userId, EmployerType employerType, Integer locationId, String bio, String companyName, String businessId, String websiteLink, String profileImageUrl, boolean isVerified, Instant createdAt, Instant updatedAt, ProfileStatus status) {
+    public EmployerProfileResponse(Long employerProfileId, String userId, EmployerType employerType, String streetAddress, String postalCode, String city, String country, String bio, String companyName, String businessId, String websiteLink, String profileImageUrl, boolean isVerified, Instant createdAt, Instant updatedAt, ProfileStatus status) {
         this.employerProfileId = employerProfileId;
         this.userId = userId;
         this.employerType = employerType;
-        this.locationId = locationId;
+        this.streetAddress = streetAddress;
+        this.postalCode = postalCode;
+        this.city = city;
+        this.country = country;
         this.bio = bio;
         this.companyName = companyName;
         this.businessId = businessId;
@@ -64,12 +70,36 @@ public class EmployerProfileResponse {
         this.employerType = employerType;
     }
 
-    public Integer getLocationId() {
-        return locationId;
+    public String getStreetAddress() {
+        return streetAddress;
     }
 
-    public void setLocationId(Integer locationId) {
-        this.locationId = locationId;
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
     }
 
     public String getBio() {

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/Location.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/Location.java
@@ -1,0 +1,95 @@
+package com.jttam.glig.domain.location;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "location")
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id")
+    private Integer locationId;
+
+    @Column(name = "street_address")
+    private String streetAddress;
+
+    @Column(name = "postal_code")
+    private String postalCode;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "country", nullable = false)
+    private String country;
+
+    @Column(name = "latitude", precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 9, scale = 7)
+    private BigDecimal longitude;
+
+    // --- Getters and Setters ---
+
+    public Integer getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(Integer locationId) {
+        this.locationId = locationId;
+    }
+
+    public String getStreetAddress() {
+        return streetAddress;
+    }
+
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(BigDecimal latitude) {
+        this.latitude = latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(BigDecimal longitude) {
+        this.longitude = longitude;
+    }
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationController.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationController.java
@@ -1,0 +1,26 @@
+package com.jttam.glig.domain.location;
+
+import com.jttam.glig.domain.location.dto.LocationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/locations")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    public LocationController(LocationService locationService) {
+        this.locationService = locationService;
+    }
+
+    /**
+     * NECESSARY: Gets the full details of a single location by its ID.
+     * This is used to display the location(s) for a specific Task.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<LocationResponse> getLocationById(@PathVariable Integer id) {
+        LocationResponse response = locationService.getLocation(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationMapper.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationMapper.java
@@ -1,0 +1,25 @@
+package com.jttam.glig.domain.location;
+
+import com.jttam.glig.domain.location.dto.LocationRequest;
+import com.jttam.glig.domain.location.dto.LocationResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+    componentModel = "spring",
+    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface LocationMapper {
+
+    LocationResponse toLocationResponse(Location location);
+
+    @Mapping(target = "locationId", ignore = true)
+    Location toLocation(LocationRequest request);
+
+    @Mapping(target = "locationId", ignore = true)
+    void updateLocationFromDto(LocationRequest request, @MappingTarget Location location);
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationRepository.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationRepository.java
@@ -1,0 +1,10 @@
+package com.jttam.glig.domain.location;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Integer> {
+    List<Location> findByCityContainingIgnoreCase(String query);
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationService.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/LocationService.java
@@ -1,0 +1,30 @@
+package com.jttam.glig.domain.location;
+
+import com.jttam.glig.domain.location.dto.LocationResponse;
+import com.jttam.glig.exception.custom.NotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LocationService {
+
+    private final LocationRepository locationRepository;
+    private final LocationMapper locationMapper;
+
+    @Autowired
+    public LocationService(LocationRepository locationRepository, LocationMapper locationMapper) {
+        this.locationRepository = locationRepository;
+        this.locationMapper = locationMapper;
+    }
+
+    /**
+     * Retrieves a location by its ID.
+     */
+    @Transactional(readOnly = true)
+    public LocationResponse getLocation(Integer locationId) {
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new NotFoundException("NOT_FOUND", "Location not found with id: " + locationId));
+        return locationMapper.toLocationResponse(location);
+    }
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/dto/LocationRequest.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/dto/LocationRequest.java
@@ -1,0 +1,76 @@
+package com.jttam.glig.domain.location.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public class LocationRequest {
+
+    @Size(max = 255, message = "Street address cannot exceed 255 characters")
+    private String streetAddress;
+
+    @Size(max = 20, message = "Postal code cannot exceed 20 characters")
+    private String postalCode;
+
+    @NotBlank(message = "City cannot be blank")
+    @Size(max = 100, message = "City cannot exceed 100 characters")
+    private String city;
+
+    @NotBlank(message = "Country cannot be blank")
+    @Size(max = 100, message = "Country cannot exceed 100 characters")
+    private String country;
+
+    private BigDecimal latitude;
+
+    private BigDecimal longitude;
+
+    // --- Getters and Setters ---
+
+    public String getStreetAddress() {
+        return streetAddress;
+    }
+
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(BigDecimal latitude) {
+        this.latitude = latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(BigDecimal longitude) {
+        this.longitude = longitude;
+    }
+}

--- a/backend/glig/src/main/java/com/jttam/glig/domain/location/dto/LocationResponse.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/location/dto/LocationResponse.java
@@ -1,0 +1,72 @@
+package com.jttam.glig.domain.location.dto;
+
+import java.math.BigDecimal;
+
+public class LocationResponse {
+
+    private Integer locationId;
+    private String streetAddress;
+    private String postalCode;
+    private String city;
+    private String country;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    // --- Getters and Setters ---
+
+    public Integer getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(Integer locationId) {
+        this.locationId = locationId;
+    }
+
+    public String getStreetAddress() {
+        return streetAddress;
+    }
+
+    public void setStreetAddress(String streetAddress) {
+        this.streetAddress = streetAddress;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(BigDecimal latitude) {
+        this.latitude = latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(BigDecimal longitude) {
+        this.longitude = longitude;
+    }
+}

--- a/backend/glig/src/main/java/com/jttam/glig/exception/custom/ConflictException.java
+++ b/backend/glig/src/main/java/com/jttam/glig/exception/custom/ConflictException.java
@@ -1,0 +1,18 @@
+package com.jttam.glig.exception.custom;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+    private final String errorCode;
+
+    public ConflictException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend/glig/src/main/resources/application.yml
+++ b/backend/glig/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
         username: sa
         password: password
 server:
+    port: 8080
     servlet:
         context-path: /api
 okta:

--- a/backend/glig/src/test/java/com/jttam/glig/domain/employerprofile/EmployerProfileServiceTest.java
+++ b/backend/glig/src/test/java/com/jttam/glig/domain/employerprofile/EmployerProfileServiceTest.java
@@ -41,14 +41,23 @@ class EmployerProfileServiceTest {
         employerProfile.setEmployerProfileId(1L);
         employerProfile.setUserId(userId);
         employerProfile.setCompanyName("Test Corp");
+        employerProfile.setStreetAddress("123 Test St");
+        employerProfile.setCity("Testville");
+        employerProfile.setCountry("Testland");
         employerProfile.setStatus(ProfileStatus.ACTIVE);
 
         createRequest = new CreateEmployerProfileRequest();
         createRequest.setCompanyName("Test Corp");
+        createRequest.setStreetAddress("123 Test St");
+        createRequest.setCity("Testville");
+        createRequest.setCountry("Testland");
 
         employerProfileResponse = new EmployerProfileResponse();
         employerProfileResponse.setEmployerProfileId(1L);
         employerProfileResponse.setCompanyName("Test Corp");
+        employerProfileResponse.setStreetAddress("123 Test St");
+        employerProfileResponse.setCity("Testville");
+        employerProfileResponse.setCountry("Testland");
     }
 
     @Test
@@ -60,6 +69,7 @@ class EmployerProfileServiceTest {
 
         assertNotNull(result);
         assertEquals("Test Corp", result.getCompanyName());
+        assertEquals("123 Test St", result.getStreetAddress());
         verify(employerProfileRepository).findByUserId(userId);
     }
 
@@ -85,6 +95,7 @@ class EmployerProfileServiceTest {
 
         assertNotNull(result);
         assertEquals("Test Corp", result.getCompanyName());
+        assertEquals("123 Test St", result.getStreetAddress());
         verify(employerProfileRepository).save(any(EmployerProfile.class));
     }
 
@@ -109,6 +120,7 @@ class EmployerProfileServiceTest {
 
         assertNotNull(result);
         assertEquals("Test Corp", result.getCompanyName());
+        assertEquals("123 Test St", result.getStreetAddress());
         verify(employerProfileMapper).updateEmployerProfileFromDto(createRequest, employerProfile);
         verify(employerProfileRepository).save(employerProfile);
     }

--- a/backend/glig/src/test/java/com/jttam/glig/domain/location/LocationServiceTest.java
+++ b/backend/glig/src/test/java/com/jttam/glig/domain/location/LocationServiceTest.java
@@ -1,0 +1,79 @@
+package com.jttam.glig.domain.location;
+
+import com.jttam.glig.domain.location.dto.LocationResponse;
+import com.jttam.glig.exception.custom.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationServiceTest {
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private LocationMapper locationMapper;
+
+    @InjectMocks
+    private LocationService locationService;
+
+    private Location location;
+    private LocationResponse locationResponse;
+    private static final Integer LOCATION_ID = 1;
+
+    @BeforeEach
+    void setUp() {
+        // Create common test objects
+        location = new Location();
+        location.setLocationId(LOCATION_ID);
+        location.setCity("Helsinki");
+
+        locationResponse = new LocationResponse();
+        locationResponse.setLocationId(LOCATION_ID);
+        locationResponse.setCity("Helsinki");
+    }
+
+    @Test
+    void getLocation_shouldReturnLocation_whenFound() {
+        // Given: We tell the mocks how to behave
+        when(locationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location));
+        when(locationMapper.toLocationResponse(location)).thenReturn(locationResponse);
+
+        // When: We call the actual service method
+        LocationResponse result = locationService.getLocation(LOCATION_ID);
+
+        // Then: We assert that the result is correct
+        assertThat(result).isNotNull();
+        assertThat(result.getLocationId()).isEqualTo(LOCATION_ID);
+        assertThat(result.getCity()).isEqualTo("Helsinki");
+
+        // And verify that the dependencies were called
+        verify(locationRepository).findById(LOCATION_ID);
+        verify(locationMapper).toLocationResponse(location);
+    }
+
+    @Test
+    void getLocation_shouldThrowNotFoundException_whenNotFound() {
+        // Given: The repository will return an empty optional, simulating a not-found scenario
+        when(locationRepository.findById(LOCATION_ID)).thenReturn(Optional.empty());
+
+        // When & Then: We assert that calling the service method throws the expected exception
+        assertThrows(NotFoundException.class, () -> {
+            locationService.getLocation(LOCATION_ID);
+        });
+
+        // And verify that the repository was called
+        verify(locationRepository).findById(LOCATION_ID);
+    }
+}


### PR DESCRIPTION
Implements the full backend stack for the Location entity.

The new location module includes:
- Location JPA entity with columns for address, city, country, etc.
- LocationRepository with a derived query for searching.
- LocationRequest and LocationResponse DTOs.
- LocationMapper for conversions between the entity and DTOs.
- LocationService and LocationController focused on providing read-only data to the UI.

Additionally, this commit refactors the EmployerProfile module to simplify its location handling for the scope of the project.

- Adds direct location attributes (streetAddress, postalCode, city, country) to the EmployerProfile entity, its DTOs, and mapper.
- This denormalization makes profile management simpler while keeping the shared Location model for Tasks.