### PR TITLE
Refactor profiles to use User entity relationship instead of String u…

### DIFF
--- a/backend/glig/src/main/java/com/jttam/glig/domain/apply/ApplyControllerService.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/apply/ApplyControllerService.java
@@ -66,17 +66,11 @@ public class ApplyControllerService {
         Task task = taskRepository.getReferenceById(taskId);
         User user = userRepository.getReferenceById(username);
 
-        if (user != null) {
-            if (task != null) {
-                Apply newApply = mapper.toApplyEntity(applyDto);
-                newApply.setUser(user);
-                newApply.setTask(task);
-                applyRepository.save(newApply);
-                return new ResponseEntity<>(applyDto, HttpStatus.CREATED);
-            }
-            throw new NotFoundException("TASK_NOT_FOUND", "Cannot find task by given taskId");
-        }
-        throw new NotFoundException("USER_NOT_FOUND", "Cannot find user for given username in jwt");
+        Apply newApply = mapper.toApplyEntity(applyDto);
+        newApply.setUser(user);
+        newApply.setTask(task);
+        applyRepository.save(newApply);
+        return new ResponseEntity<>(applyDto, HttpStatus.CREATED);
     }
 
     @Transactional

--- a/backend/glig/src/main/java/com/jttam/glig/domain/common/BaseProfile.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/common/BaseProfile.java
@@ -1,10 +1,14 @@
 package com.jttam.glig.domain.common;
 
+import com.jttam.glig.domain.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -21,10 +25,10 @@ import java.time.Instant;
 @MappedSuperclass
 public abstract class BaseProfile implements Serializable {
 
-    @NotBlank(message = "User ID cannot be blank.")
-    @Size(max = 255, message = "User ID must be less than 255 characters.")
-    @Column(name = "user_id", unique = true, nullable = false, updatable = false)
-    private String userId;
+    @NotNull(message = "User cannot be null.")
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true, updatable = false)
+    private User user;
 
     @NotBlank(message = "First name cannot be blank.")
     @Size(max = 100, message = "First name must be less than 100 characters.")
@@ -94,8 +98,8 @@ public abstract class BaseProfile implements Serializable {
     protected BaseProfile() {
     }
 
-    public BaseProfile(String userId, String streetAddress, String postalCode, String city, String country, String bio, String websiteLink, String profileImageUrl, boolean isVerified) {
-        this.userId = userId;
+    public BaseProfile(User user, String streetAddress, String postalCode, String city, String country, String bio, String websiteLink, String profileImageUrl, boolean isVerified) {
+        this.user = user;
         this.streetAddress = streetAddress;
         this.postalCode = postalCode;
         this.city = city;
@@ -108,12 +112,12 @@ public abstract class BaseProfile implements Serializable {
 
     // --- Getters and Setters ---
 
-    public String getUserId() {
-        return userId;
+    public User getUser() {
+        return user;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
+    public void setUser(User user) {
+        this.user = user;
     }
 
     public String getFirstName() {

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfile.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfile.java
@@ -3,6 +3,7 @@ package com.jttam.glig.domain.employerprofile;
 import org.hibernate.annotations.Where;
 
 import com.jttam.glig.domain.common.BaseProfile;
+import com.jttam.glig.domain.user.User;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -37,10 +38,10 @@ public class EmployerProfile extends BaseProfile {
         super();
     }
 
-    public EmployerProfile(String userId, EmployerType employerType, String streetAddress, String postalCode,
+    public EmployerProfile(User user, EmployerType employerType, String streetAddress, String postalCode,
             String city, String country, String bio, String companyName, String businessId, String websiteLink,
             String profileImageUrl, boolean isVerified) {
-        super(userId, streetAddress, postalCode, city, country, bio, websiteLink, profileImageUrl, isVerified);
+        super(user, streetAddress, postalCode, city, country, bio, websiteLink, profileImageUrl, isVerified);
         this.employerType = employerType;
         this.companyName = companyName;
         this.businessId = businessId;

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileMapper.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileMapper.java
@@ -9,18 +9,20 @@ import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface EmployerProfileMapper {
+    @Mapping(target = "userId", source = "user.userName")
     EmployerProfileResponse toResponse(EmployerProfile employerProfile);
+    
     @Mapping(target = "employerProfileId", ignore = true)
-    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "verified", ignore = true)
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     @Mapping(target = "deletedAt", ignore = true)
-    
     EmployerProfile toEntity(EmployerProfileRequest request);
+    
     @Mapping(target = "employerProfileId", ignore = true)
-    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "verified", ignore = true)
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileRepository.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/employerprofile/EmployerProfileRepository.java
@@ -2,11 +2,13 @@ package com.jttam.glig.domain.employerprofile;
 
 import java.util.Optional;
 
+import com.jttam.glig.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmployerProfileRepository extends JpaRepository<EmployerProfile, Long> {
-    Optional<EmployerProfile> findByUserId(String userId);
-    boolean existsByUserId(String userId);
+    Optional<EmployerProfile> findByUser(User user);
+    Optional<EmployerProfile> findByUser_UserId(String userId);
+    boolean existsByUser(User user);
 }

--- a/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfile.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfile.java
@@ -1,6 +1,7 @@
 package com.jttam.glig.domain.taskerprofile;
 
 import com.jttam.glig.domain.common.BaseProfile;
+import com.jttam.glig.domain.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -23,6 +24,18 @@ public class TaskerProfile extends BaseProfile {
 
     @Column(name = "average_rating", precision = 3, scale = 2)
     private BigDecimal averageRating;
+
+    // Constructors
+    public TaskerProfile() {
+        super();
+    }
+
+    public TaskerProfile(User user, String streetAddress, String postalCode,
+                         String city, String country, String bio, String websiteLink,
+                         String profileImageUrl, boolean isVerified, BigDecimal averageRating) {
+        super(user, streetAddress, postalCode, city, country, bio, websiteLink, profileImageUrl, isVerified);
+        this.averageRating = averageRating;
+    }
 
     // Getters and setters
     public Long getTaskerProfileId() {

--- a/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfileMapper.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfileMapper.java
@@ -12,7 +12,7 @@ public interface TaskerProfileMapper {
 
     @Mapping(target = "taskerProfileId", ignore = true)
     @Mapping(target = "averageRating", ignore = true)
-    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "verified", ignore = true)
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
@@ -20,11 +20,12 @@ public interface TaskerProfileMapper {
     @Mapping(target = "deletedAt", ignore = true)
     TaskerProfile toEntity(TaskerProfileRequest request);
 
+    @Mapping(target = "userId", source = "user.userName")
     TaskerProfileResponse toResponse(TaskerProfile taskerProfile);
 
     @Mapping(target = "taskerProfileId", ignore = true)
     @Mapping(target = "averageRating", ignore = true)
-    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "verified", ignore = true)
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfileRepository.java
+++ b/backend/glig/src/main/java/com/jttam/glig/domain/taskerprofile/TaskerProfileRepository.java
@@ -1,5 +1,6 @@
 package com.jttam.glig.domain.taskerprofile;
 
+import com.jttam.glig.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface TaskerProfileRepository extends JpaRepository<TaskerProfile, Long> {
-    Optional<TaskerProfile> findByUserId(String userId);
+    Optional<TaskerProfile> findByUser(User user);
+    Optional<TaskerProfile> findByUser_UserId(String userId);
 }


### PR DESCRIPTION
…serId

- Changed BaseProfile from String userId to @OneToOne User relationship
- Updated TaskerProfile and EmployerProfile constructors to accept User entity
- Modified TaskerProfileRepository and EmployerProfileRepository to use User-based queries
- Updated TaskerProfileService and EmployerProfileService to fetch User entities
- Fixed mappers to handle User entity mapping (user.userName -> userId in responses)
- Updated all service tests to mock User entities and new repository methods
- Removed dead code in ApplyControllerService (unnecessary null checks)
- All tests passing (16/16)